### PR TITLE
Remove deprecated PHP-Textile method calls

### DIFF
--- a/src/lib/Textpattern/Fluxbb/Textile/Parser.php
+++ b/src/lib/Textpattern/Fluxbb/Textile/Parser.php
@@ -41,7 +41,7 @@ class Parser extends Textile
     /**
      * Language identifiers.
      *
-     * @var array|string
+     * @var string[]
      */
 
     private $extraCodeLanguageIdentifiers = array(
@@ -75,19 +75,25 @@ class Parser extends Textile
      * {@inheritdoc}
      */
 
-    public function __construct($doctype = 'html5')
+    protected function configure()
     {
-        $this->extraCodeLanguageIdentifiers = join('|', $this->extraCodeLanguageIdentifiers);
-        parent::__construct($doctype);
+        $this->extraCodeLanguageIdentifiers = implode('|', $this->extraCodeLanguageIdentifiers);
+
+        $this
+            ->setDocumentType('html5')
+            ->setRestricted(true)
+            ->setLite(false)
+            ->setImages(false)
+            ->setLinkRelationShip('nofollow');
     }
 
     /**
      * {@inheritdoc}
      */
 
-    public function textileRestricted($text, $lite = true, $noimage = true, $rel = 'nofollow')
+    public function parse($text)
     {
-        $text = parent::textileRestricted($text, $lite, $noimage, $rel);
+        $text = parent::parse($text);
         $text = $this->extraCodeLanguageHinting($text);
         return $text;
     }

--- a/src/setup/patches/feature-textpattern-forum.patch
+++ b/src/setup/patches/feature-textpattern-forum.patch
@@ -1708,11 +1708,11 @@ index b7eb4bd0..a98356c3 100644
 -				$text .= '</p><div class="codebox"><pre'.(($num_lines > 28) ? ' class="vscroll"' : '').'><code>'.pun_trim($inside[$i], "\n\r").'</code></pre></div><p>';
 -			}
 -		}
-+		return $textile->textileRestricted($text, false, true);
++		return $textile->setImages(true)->parse($text);
  	}
  
 -	return clean_paragraphs($text);
-+	return $textile->textileRestricted($text, false, false);
++	return $textile->setImages(false)->parse($text);
  }
  
  
@@ -1749,11 +1749,11 @@ index b7eb4bd0..a98356c3 100644
 -	$text = str_replace($pattern, $replace, $text);
 +	if (defined('PUN_NEW_MEMBER') && $cur_post['group_id'] == PUN_NEW_MEMBER)
 +	{
-+		return $textile->textileRestricted($text, false, true);
++		return $textile->setImages(true)->parse($text);
 +	}
  
 -	return clean_paragraphs($text);
-+	return $textile->textileRestricted($text, false, false);
++	return $textile->setImages(false)->parse($text);
  }
 diff --git a/index.php b/index.php
 index 888cc91a..b8d0a3b9 100644


### PR DESCRIPTION
Updates PHP-Textile usage to use up-to-date parser methods instead of the deprecated ones brought up in the issue #282.

This code is completely untested as I do not have the project installed locally; it might not work, so test it before using it in production. As the signatures do change, you will also need to re-apply the FluxBB patch on top of the deployed project and potentially regenerate the patch, if it is not up-to-date with the FluxBB version being used.

Fixes #282 